### PR TITLE
8.x-6.x Pagination fixes

### DIFF
--- a/js/search-ajaxify.js
+++ b/js/search-ajaxify.js
@@ -140,8 +140,10 @@
           }
         });
 
+        let searchForm = $('[data-ajax-search-form]');
+
         let data = {
-          keyword: $('.js-form-item-keyword').find('input').val()
+          keyword: searchForm.find('input[name="keyword"]').val()
         };
 
         if (typeof page !== 'undefined') {

--- a/js/search-ajaxify.js
+++ b/js/search-ajaxify.js
@@ -141,7 +141,7 @@
         });
 
         let data = {
-          keyword: $('[data-ajax-search-form]').find('input').val()
+          keyword: $('.js-form-item-keyword').find('input').val()
         };
 
         if (typeof page !== 'undefined') {
@@ -158,7 +158,10 @@
           history.pushState({}, '', '?' + $.param(data));
         }
 
-        $.post(url, data, function (data) {
+        // Append the requested page number to the url, since drupal's
+        // PagerManager uses the 'page' param from the incoming request.
+        let paged_url = url + '?' + $.param(data);
+        $.post(paged_url, data, function (data) {
           // Simulate a drupal.ajax response to correctly parse data.
           let ajaxObject = Drupal.ajax({
             url: '',

--- a/src/Controller/SearchController.php
+++ b/src/Controller/SearchController.php
@@ -477,6 +477,10 @@ class SearchController extends ControllerBase {
    *   Pager render array.
    */
   protected function renderPager(ParameterBag $query, int $total, int $size) {
+    // Tell drupal about a pager being rendered. This
+    // is necessary to make pager links work correctly.
+    \Drupal::service('pager.manager')->createPager($total, $size);
+
     return [
       '#theme' => 'cgk_pager',
       '#tags' => [


### PR DESCRIPTION
Fixes:
- Pager links should contain page number & keyword (currently every pager link has **/search?keyword=&page=** as href value)
- Navigating to specific page using the 'page' parameter in the url should work correctly (currently the pager will not respect the given 'page' param value)